### PR TITLE
Fix Worktree Backlog Item ID Bug

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -603,7 +603,9 @@ export default function App() {
         // 1. Reserve slot and set task to initializing
         setSlots(prev => prev.map(s => s.id === slotId ? { ...s, taskId } : s));
 
-        const branchName = `feat/${tasks.find(t => t.id === taskId)?.group.toLowerCase().replace(/\s+/g, '-')}-${taskId.substring(0, 4)}`;
+        const taskItem = tasks.find(t => t.id === taskId);
+        const branchId = taskItem?.issueNumber ?? taskId;
+        const branchName = `feat/${taskItem?.group.toLowerCase().replace(/\s+/g, '-')}-${branchId}`;
 
         setTasks(prev => prev.map(t => {
             if (t.id === taskId) {

--- a/components/Step2_Issues.tsx
+++ b/components/Step2_Issues.tsx
@@ -142,7 +142,7 @@ export const Step2_Issues: React.FC<Props> = ({ tasks, onPromoteToIssue, onPromo
                                 <p className="text-sm text-slate-400 mb-3 leading-relaxed">{task.description}</p>
                                 <div className="flex items-center gap-2 text-xs relative z-10">
                                     <span className="bg-slate-800 px-2 py-1 rounded text-slate-400 border border-slate-700">{task.group}</span>
-                                    <span className="text-slate-600 font-mono">ID: {task.id.substring(0,6)}</span>
+                                    <span className="text-slate-600 font-mono">ID: {task.issueNumber ?? task.id}</span>
                                 </div>
                             </div>
                         );

--- a/components/Step3_Worktrees.tsx
+++ b/components/Step3_Worktrees.tsx
@@ -539,7 +539,7 @@ export const Step3_Worktrees: React.FC<Props> = ({
                             <div key={task.id} className="p-3 border border-slate-800 rounded-xl hover:bg-slate-800/50 transition-colors bg-slate-900/30 group">
                                 <div className="flex justify-between items-center mb-2 gap-2">
                                     <span className="text-[10px] bg-slate-800 text-slate-400 px-1.5 py-0.5 rounded border border-slate-700 font-mono">
-                                        #{task.id.substring(0, 4)}
+                                        #{task.issueNumber ?? task.id}
                                     </span>
                                     <span className={`text-[10px] uppercase font-bold px-2 py-0.5 rounded-full border ${PRIORITY_BADGES[task.priority]}`}>
                                         {task.priority}


### PR DESCRIPTION
Investigate and resolve the issue where Worktree backlog item IDs are consistently being assigned as `#gh-1` or `#gh-2`. This likely stems from incorrect ID generation or retrieval logic within the Worktree integration. The fix should ensure unique and correct IDs are assigned to all backlog items.

**Group:** Backend
**Priority:** High

*Generated by Flowize*

Closes #23