### PR TITLE
Add issue counter to Worktrees backlog column

### DIFF
--- a/components/Step3_Worktrees.tsx
+++ b/components/Step3_Worktrees.tsx
@@ -895,8 +895,15 @@ export const Step3_Worktrees: React.FC<Props> = ({
             <BacklogDroppableZone>
             <div className="xl:col-span-1 bg-slate-100 dark:bg-slate-900/50 backdrop-blur-sm rounded-2xl border border-slate-200 dark:border-slate-800 flex flex-col overflow-hidden h-full min-h-[460px] xl:max-h-[calc(100vh-12rem)]">
                 <div className="p-4 border-b border-slate-200 dark:border-slate-800 bg-slate-100 dark:bg-slate-900/80 flex-shrink-0">
-                    <h3 className="font-semibold text-slate-900 dark:text-slate-300 flex items-center gap-2">
-                        <GitBranch className="w-4 h-4 text-orange-600 dark:text-orange-400" /> Issue Backlog
+                    <h3 className="font-semibold text-slate-900 dark:text-slate-300 flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                            <GitBranch className="w-4 h-4 text-orange-600 dark:text-orange-400" /> Issue Backlog
+                            {backlog.length > 0 && (
+                                <span className="ml-1 px-2 py-0.5 rounded-full bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300 text-xs font-medium">
+                                    {backlog.length}
+                                </span>
+                            )}
+                        </div>
                         {/* Bridge Required Notice */}
                         <span className={`px-2 py-0.5 rounded inline-flex items-center gap-1 ${bridgeHealth?.status === 'healthy'
                             ? 'bg-emerald-50 dark:bg-emerald-950/20 border border-emerald-200/50 dark:border-emerald-800/30'
@@ -912,15 +919,21 @@ export const Step3_Worktrees: React.FC<Props> = ({
                                 }`} />
 
                             {bridgeHealth?.status === 'healthy' && (
-                                <span className={`text-[10px] text-emerald-700 dark:text-emerald-300`}>Bridge active</span>
+                                <span className="hidden xl:inline text-[10px] text-emerald-700 dark:text-emerald-300" title="Bridge active">
+                                    Bridge active
+                                </span>
                             )}
 
                             {bridgeHealth?.status === 'unhealthy' && (
-                                <span className={`text-[10px] text-red-700 dark:text-red-300`}>Bridge required</span>
+                                <span className="hidden xl:inline text-[10px] text-red-700 dark:text-red-300" title="Bridge required">
+                                    Bridge required
+                                </span>
                             )}
 
                             {bridgeHealth?.status !== 'healthy' && bridgeHealth?.status !== 'unhealthy' && (
-                                <span className={`text-[10px] text-yellow-700 dark:text-yellow-300`}>Bridge required</span>
+                                <span className="hidden xl:inline text-[10px] text-yellow-700 dark:text-yellow-300" title="Bridge required">
+                                    Bridge required
+                                </span>
                             )}
                         </span>
                     </h3>


### PR DESCRIPTION
Implement a numeric counter in the 'Issue Backlog' column on the Worktrees page to display the total number of remaining issues. The counter should update dynamically based on the current items in the backlog list.

Closes #77